### PR TITLE
Add expression field to cue_config

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@ Notable changes between releases.
 
 ## Latest
 
+* Add `expression` field to `cue_config` ([#3](https://github.com/poseidon/terraform-provider-cue/pull/3))
+  * Evaluate an expression instead of an entire config
+
 ## v0.1.0
 
 * Add `cue_config` data source to evaluate CUE contents

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Define a `cue_config` data source to validate CUE `content`.
 
 ```tf
 data "cue_config" "example" {
+  pretty_print = true
   content = <<EOF
 a: 1
 b: 2
@@ -46,7 +47,6 @@ map: [string]:int
 map: {a: 1 * 5}
 map: {"b": b * 5}
 EOF
-  pretty_print = true
 }
 ```
 

--- a/internal/data_config.go
+++ b/internal/data_config.go
@@ -28,6 +28,10 @@ func dataConfig() *schema.Resource {
 				},
 				Optional: true,
 			},
+			"expression": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"pretty_print": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -79,6 +83,14 @@ func dataConfigRead(ctx context.Context, d *schema.ResourceData, meta any) diag.
 		value, err = loadPaths(cuectx, paths)
 		if err != nil {
 			return diag.FromErr(err)
+		}
+	}
+
+	// lookup an expression
+	if expression, ok := d.Get("expression").(string); ok && expression != "" {
+		value = value.LookupPath(cue.ParsePath(expression))
+		if err := value.Err(); err != nil {
+			return diag.FromErr(fmt.Errorf("expression error: %v", err))
 		}
 	}
 

--- a/internal/data_config_test.go
+++ b/internal/data_config_test.go
@@ -67,6 +67,19 @@ data "cue_config" "example" {
 
 const outputWithPaths = `{"a":1,"b":2,"sum":3,"l":[1,2],"layout":{"boxes":[{"color":"red","row":0,"column":0},{"color":"blue","row":0,"column":1},{"color":"green","row":1,"column":0},{"color":"yellow","row":1,"column":1}]},"map":{"a":5,"b":10},"ben":{"name":"Ben","age":31,"human":true}}`
 
+const cueWithExpression = `
+data "cue_config" "example" {
+	content = <<EOT
+a: 1
+b: 2
+_hidden: 3
+EOT
+	expression = "a"
+}
+`
+
+const outputWithExpression = `1`
+
 func TestConfigRender(t *testing.T) {
 	r.UnitTest(t, r.TestCase{
 		Providers: testProviders,
@@ -87,6 +100,12 @@ func TestConfigRender(t *testing.T) {
 				Config: cueWithPaths,
 				Check: r.ComposeTestCheckFunc(
 					r.TestCheckResourceAttr("data.cue_config.example", "rendered", outputWithPaths),
+				),
+			},
+			{
+				Config: cueWithExpression,
+				Check: r.ComposeTestCheckFunc(
+					r.TestCheckResourceAttr("data.cue_config.example", "rendered", outputWithExpression),
 				),
 			},
 		},


### PR DESCRIPTION
* Evaluate an expression instead of an entire config when expression is set to a field path in the configuration