### PR TITLE
Allow CUE content and paths to be evaluated together

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ Notable changes between releases.
 
 ## Latest
 
+## v0.4.0
+
+* Allow unifying `content` and `path` based CUE expressions ([#48](https://github.com/poseidon/terraform-provider-cue/pull/48))
+
 ## v0.3.0
 
 * Update CUE from v0.4.3 to [v0.5.0](https://github.com/cue-lang/cue/releases/tag/v0.5.0)

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,13 @@ release: \
 	_output/plugin-darwin-arm64.zip \
 	_output/plugin-windows-amd64.zip
 
+release-test: OS_ARCH=$(shell go env GOOS)_$(shell go env GOARCH)
+release-test: DEST=$(HOME)/.terraform.d/plugins/terraform.localhost/poseidon/cue/$(SEMVER)/$(OS_ARCH)
+release-test: NAME=_output/terraform-provider-cue_$(SEMVER)_$(OS_ARCH)
+release-test:
+	@mkdir -p $(DEST)
+	cp $(NAME)/* $(DEST)
+
 _output/plugin-%.zip: NAME=terraform-provider-cue_$(SEMVER)_$(subst -,_,$*)
 _output/plugin-%.zip: DEST=_output/$(NAME)
 _output/plugin-%.zip: _output/%/terraform-provider-cue

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/cue"
-      version = "0.2.0"
+      version = "0.4.0"
     }
   }
 }
@@ -40,21 +40,21 @@ Define a `cue_config` data source to validate CUE `content`.
 ```tf
 data "cue_config" "example" {
   pretty_print = true
-  content = <<EOF
-a: 1
-b: 2
-sum: a + b
-_hidden: 3
-l: [a, b]
+  content = <<-EOT
+    a: 1
+    b: 2
+    sum: a + b
+    _hidden: 3
+    l: [a, b]
 
-map: [string]:int
-map: {a: 1 * 5}
-map: {"b": b * 5}
-EOF
+    map: [string]:int
+    map: {a: 1 * 5}
+    map: {"b": b * 5}
+  EOT
 }
 ```
 
-Alternately, provide `paths` to CUE files (supports imports).
+Optionally provide `paths` to CUE files (supports imports).
 
 ```tf
 data "cue_config" "example" {
@@ -62,7 +62,24 @@ data "cue_config" "example" {
     "core.cue",
     "box.cue",
   ]
-  pretty_print = false
+}
+```
+
+Or unify `content` and `path` based expressions together.
+
+```tf
+data "cue_config" "example" {
+  paths = [
+    "partial.cue",
+  ]
+  content = <<-EOT
+    package example
+
+		_config: {
+			name: "ACME"
+			amount: "$20.00"
+		}
+  EOT
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ terraform {
   required_providers {
     ct = {
       source  = "poseidon/cue"
-      version = "0.2.0"
+      version = "0.4.0"
     }
   }
 }
@@ -29,22 +29,22 @@ Define a `cue_config` data source to validate CUE `content`.
 
 ```tf
 data "cue_config" "example" {
-  content = <<EOF
-a: 1
-b: 2
-sum: a + b
-_hidden: 3
-l: [a, b]
-
-map: [string]:int
-map: {a: 1 * 5}
-map: {"b": b * 5}
-EOF
   pretty_print = true
+  content = <<-EOT
+    a: 1
+    b: 2
+    sum: a + b
+    _hidden: 3
+    l: [a, b]
+
+    map: [string]:int
+    map: {a: 1 * 5}
+    map: {"b": b * 5}
+  EOT
 }
 ```
 
-Alternately, provide `paths` to CUE files (supports imports).
+Optionally provide `paths` to CUE files (supports imports).
 
 ```tf
 data "cue_config" "example" {
@@ -52,7 +52,24 @@ data "cue_config" "example" {
     "core.cue",
     "box.cue",
   ]
-  pretty_print = false
+}
+```
+
+Or unify `content` and `path` based expressions together.
+
+```tf
+data "cue_config" "example" {
+  paths = [
+    "partial.cue",
+  ]
+  content = <<-EOT
+    package example
+
+		_config: {
+			name: "ACME"
+			amount: "$20.00"
+		}
+  EOT
 }
 ```
 

--- a/examples/example.tf
+++ b/examples/example.tf
@@ -1,20 +1,15 @@
 data "cue_config" "example" {
-  content = <<EOF
-a: 1
-b: 2
-sum: a + b
-_hidden: 3
-l: [a, b]
+  content = <<-EOT
+    a: 1
+    b: 2
+    sum: a + b
+    _hidden: 3
+    l: [a, b]
 
-map: [string]:int
-map: {a: 1 * 5}
-map: {"b": b * 5}
-EOF
-}
-
-output "out" {
-  description = "Show Cue rendered as JSON"
-  value       = data.cue_config.example.rendered
+    map: [string]:int
+    map: {a: 1 * 5}
+    map: {"b": b * 5}
+  EOT
 }
 
 data "cue_config" "example2" {
@@ -24,8 +19,31 @@ data "cue_config" "example2" {
   ]
 }
 
+data "cue_config" "example3" {
+  paths = [
+    "partial.cue",
+  ]
+  content = <<-EOT
+    package examples
+
+		_config: {
+			name: "ACME"
+			amount: "$20.00"
+		}
+  EOT
+}
+
+output "out" {
+  description = "Show Cue content rendered as JSON"
+  value       = data.cue_config.example.rendered
+}
 
 output "out2" {
-  description = "Show Cue rendered as JSON"
+  description = "Show Cue files rendered as JSON"
   value       = data.cue_config.example2.rendered
+}
+
+output "out3" {
+  description = "Show Cue content+files rendered as JSON"
+  value       = data.cue_config.example3.rendered
 }

--- a/examples/partial.cue
+++ b/examples/partial.cue
@@ -1,0 +1,7 @@
+package examples
+
+{
+  title: "Invoice"
+  customer: _config.name
+  bill: _config.amount
+}

--- a/examples/providers.tf
+++ b/examples/providers.tf
@@ -4,7 +4,8 @@ terraform {
   required_providers {
     cue = {
       source  = "poseidon/cue"
-      version = "0.3.0"
+      #source = "terraform.localhost/poseidon/cue"
+      version = "0.4.0"
     }
   }
 }


### PR DESCRIPTION
* There is a way for CUE to evaluate string expressions and path-based expressions in a single build, by using the loader with an Overlay option so that it will load the content as though it were a file
* Drop the restriction that `content` and `paths` be mutually exclusive, you can set both. Add an example and docs